### PR TITLE
Deprecate postUserNameAndPassword

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -9,18 +9,12 @@ Following this guide will allow you to:
 See the [official Mastodon docs](https://docs.joinmastodon.org/methods/apps/) for further API methods,
 and this project's code for implementation details.
 
-Code examples in this guide make use of the following variables for simplicity.
-Their values should generally *not* be hard-coded in an actual application.
+Code examples in this guide make use of the following variable for simplicity.
+Its value should generally *not* be hard-coded in an actual application.
 
 ```kotlin
 // hostname of a Mastodon server, e.g. "mastodon.social"
 val instanceHostname:String = ...
-
-// mail address of an account
-val userMail:String = ...
-
-// password of an account
-val userPassword:String = ...
 ```
 
 Additionally, this guide uses the following values that should be replaced in your application:
@@ -72,25 +66,6 @@ try {
 ## Login and get Access Token
 
 Using client ID and secret available in appRegistration, we can now get an access token to act on behalf of a user.
-
-### Using available user credentials
-
-__Kotlin__
-
-```kotlin
-// using client and appRegistration as defined above
-	
-val apps = Apps(client)
-val accessToken = apps.postUserNameAndPassword(
-	clientId = appRegistration.clientId,
-	clientSecret = appRegistration.clientSecret,
-	scope = Scope(),
-	userName = userMail,
-	password = userPassword)
-).execute()
-```
-
-### Using OAuth
 
 __Kotlin__
 

--- a/mastodon4j-rx/src/main/kotlin/com/sys1yagi/mastodon4j/rx/RxApps.kt
+++ b/mastodon4j-rx/src/main/kotlin/com/sys1yagi/mastodon4j/rx/RxApps.kt
@@ -38,6 +38,12 @@ class RxApps(client: MastodonClient) {
         }
     }
 
+    @Deprecated(
+        "This method uses grant_type 'password' which is undocumented in Mastodon API" +
+                " and should not be used in production code.",
+        ReplaceWith("getAccessToken()"),
+        DeprecationLevel.WARNING
+    )
     fun postUserNameAndPassword(
             clientId: String,
             clientSecret: String,

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Apps.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Apps.kt
@@ -10,10 +10,19 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
 
 /**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#apps
+ * Register client applications that can be used to obtain OAuth tokens.
+ * @see <a href="https://docs.joinmastodon.org/methods/apps/">Mastodon apps API methods</a>
+ *
+ * Generate and manage OAuth tokens.
+ * @see <a href="https://docs.joinmastodon.org/methods/oauth/">Mastodon oauth API methods</a>
  */
 class Apps(private val client: MastodonClient) {
-    // POST /api/v1/apps
+
+    /**
+     * Create a new application to obtain OAuth2 credentials.
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/apps/#create">Mastodon apps API methods #create</a>
+     */
     @JvmOverloads
     fun createApp(
         clientName: String,
@@ -23,76 +32,98 @@ class Apps(private val client: MastodonClient) {
     ): MastodonRequest<AppRegistration> {
         scope.validate()
         return MastodonRequest(
-                {
-                    client.post("apps",
-                        arrayListOf(
-                                "client_name=$clientName",
-                                "scopes=$scope",
-                                "redirect_uris=$redirectUris"
-                        ).apply {
-                            website?.let {
-                                add("website=${it}")
-                            }
-                        }.joinToString(separator = "&")
-                            .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
-                    )
-                },
-                {
-                    client.getSerializer().fromJson(it, AppRegistration::class.java).apply {
-                        this.instanceName = client.getInstanceName()
-                    }
+            {
+                client.post("apps",
+                    arrayListOf(
+                        "client_name=$clientName",
+                        "scopes=$scope",
+                        "redirect_uris=$redirectUris"
+                    ).apply {
+                        website?.let {
+                            add("website=${it}")
+                        }
+                    }.joinToString(separator = "&")
+                        .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
+                )
+            },
+            {
+                client.getSerializer().fromJson(it, AppRegistration::class.java).apply {
+                    this.instanceName = client.getInstanceName()
                 }
+            }
         )
     }
 
+    /**
+     * Returns a URL that can be used to display an authorization form to the user. If approved,
+     * it will create and return an authorization code, then redirect to the desired redirectUri,
+     * or show the authorization code if urn:ietf:wg:oauth:2.0:oob was requested.
+     * The authorization code can be used while requesting a token to obtain access to user-level methods.
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/oauth/#authorize">Mastodon oauth API methods #authorize</a>
+     */
     fun getOAuthUrl(clientId: String, scope: Scope, redirectUri: String = "urn:ietf:wg:oauth:2.0:oob"): String {
         val endpoint = "/oauth/authorize"
         val parameters = listOf(
-                "client_id=$clientId",
-                "redirect_uri=$redirectUri",
-                "response_type=code",
-                "scope=$scope"
+            "client_id=$clientId",
+            "redirect_uri=$redirectUri",
+            "response_type=code",
+            "scope=$scope"
         ).joinToString(separator = "&")
         return "https://${client.getInstanceName()}$endpoint?$parameters"
     }
 
-    // POST /oauth/token
+    /**
+     * Obtain an access token, to be used during API calls that are not public.
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/oauth/#token">Mastodon oauth API methods #token</a>
+     */
     @JvmOverloads
     fun getAccessToken(
-            clientId: String,
-            clientSecret: String,
-            redirectUri: String = "urn:ietf:wg:oauth:2.0:oob",
-            code: String,
-            grantType: String = "authorization_code"
+        clientId: String,
+        clientSecret: String,
+        redirectUri: String = "urn:ietf:wg:oauth:2.0:oob",
+        code: String,
+        grantType: String = "authorization_code"
     ): MastodonRequest<AccessToken> {
         val url = "https://${client.getInstanceName()}/oauth/token"
         val parameters = listOf(
-                "client_id=$clientId",
-                "client_secret=$clientSecret",
-                "redirect_uri=$redirectUri",
-                "code=$code",
-                "grant_type=$grantType"
+            "client_id=$clientId",
+            "client_secret=$clientSecret",
+            "redirect_uri=$redirectUri",
+            "code=$code",
+            "grant_type=$grantType"
         ).joinToString(separator = "&")
         return MastodonRequest(
-                {
-                    client.postUrl(url,
-                        parameters
-                            .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
-                    )
-                },
-                {
-                    client.getSerializer().fromJson(it, AccessToken::class.java)
-                }
+            {
+                client.postUrl(url,
+                    parameters
+                        .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
+                )
+            },
+            {
+                client.getSerializer().fromJson(it, AccessToken::class.java)
+            }
         )
     }
 
-    // POST /oauth/token
+    /**
+     * Obtain an access token, to be used during API calls that are not public. This method uses a grant_type
+     * that is undocumented in Mastodon API, and should NOT be used in production code. It exists for example code
+     * in this project and will be removed at a later date. getAccessToken() should be used instead.
+     */
+    @Deprecated(
+        "This method uses grant_type 'password' which is undocumented in Mastodon API" +
+                " and should not be used in production code.",
+        ReplaceWith("getAccessToken()"),
+        DeprecationLevel.WARNING
+    )
     fun postUserNameAndPassword(
-            clientId: String,
-            clientSecret: String,
-            scope: Scope,
-            userName: String,
-            password: String
+        clientId: String,
+        clientSecret: String,
+        scope: Scope,
+        userName: String,
+        password: String
     ): MastodonRequest<AccessToken> {
         val url = "https://${client.getInstanceName()}/oauth/token"
         val parameters = Parameter().apply {
@@ -105,15 +136,15 @@ class Apps(private val client: MastodonClient) {
         }.build()
 
         return MastodonRequest(
-                {
-                    client.postUrl(url,
-                        parameters
-                            .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
-                    )
-                },
-                {
-                    client.getSerializer().fromJson(it, AccessToken::class.java)
-                }
+            {
+                client.postUrl(url,
+                    parameters
+                        .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
+                )
+            },
+            {
+                client.getSerializer().fromJson(it, AccessToken::class.java)
+            }
         )
     }
 }


### PR DESCRIPTION
Discussed in #11, postUserNameAndPassword() in Apps.kt and RxApps.kt uses an undocumented grant type that should not be part of this library's public API. Deprecate both methods immediately for later removal, and also remove example code using this method from USAGE.md.

#11 should stay open until these methods are properly removed (in 2.0.0?).